### PR TITLE
Workaround/windows platform

### DIFF
--- a/backend/directory_creator.py
+++ b/backend/directory_creator.py
@@ -125,7 +125,7 @@ class DirectoryCreator:
                 outfile.write(f"export RABBITCONFIG={self.config_directory}")
         elif self.platform == "Windows":
             self.logger.info("Windows platform detected")
-            os.environ["RABBITCONFIG"] = self.installation_directory
+            os.system(f"setx RABBITCONFIG {self.config_directory}") 
 
     def create_config_file(self):
         cfg_creator = ConfigCreator(

--- a/backend/tools/config_creator.py
+++ b/backend/tools/config_creator.py
@@ -1,6 +1,7 @@
 import xml.etree.cElementTree as ET
 import os
 import sys
+import platform
 
 from tools.xml_tools import prettify
 from tools.log import setup_custom_logger

--- a/backend/tools/config_creator.py
+++ b/backend/tools/config_creator.py
@@ -1,7 +1,6 @@
 import xml.etree.cElementTree as ET
 import os
 import sys
-import platform
 
 from tools.xml_tools import prettify
 from tools.log import setup_custom_logger


### PR DESCRIPTION
Added ability to run rabbit api server on windows (directory creator must be run first, then new cmd window to get RABBITCONFIG env variable)